### PR TITLE
ログインしていないユーザーの制限

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :view_parts, only: [:index, :show]
-  # before_action :move_to_index, except: [:index, :show, :edit]
+  before_action :move_to_index, except: [:index, :new]
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   private
@@ -9,14 +9,13 @@ class ApplicationController < ActionController::Base
   end
 
   def view_parts
-    @user = "ユーザー名 (サインイン・マイページ)"
     @title = "My Web list"
   end
 
-  # def move_to_index
-  #   unless user_signed_in?
-  #     redirect_to action: :index
-  #   end
-  # end
+  def move_to_index
+    unless user_signed_in?
+      redirect_to root_path
+    end
+  end
 
 end

--- a/app/views/links/_form-link.html.haml
+++ b/app/views/links/_form-link.html.haml
@@ -1,8 +1,8 @@
 .Main-form
   = form_with model: [@category, @link], local: true, html: {class: "Form"} do |f|
     .Form__content
-      = f.text_field :name, placeholder: "サイト名を入力 google", class: "Form__area"
-      = f.text_field :url, placeholder: "URLを入力 https://www ~ ", class: "Form__area"
+      = f.text_field :name, placeholder: "サイト名を入力　　例：google", class: "Form__area"
+      = f.text_field :url, placeholder: "URLを入力　　例：https://www ~ ", class: "Form__area"
       = f.text_field :comment, placeholder: "コメントを入力してください", class: "Form__area"
     .Form__btn
       = f.submit "追加", class: "Form__btn__area"

--- a/app/views/links/edit.html.haml
+++ b/app/views/links/edit.html.haml
@@ -1,8 +1,8 @@
 .Main-form
   = form_with model: [@category, @link], local: true, html: {class: "Form"} do |f|
     .Form__content
-      = f.text_field :name, placeholder: "サイト名を入力 google", class: "Form__area"
-      = f.text_field :url, placeholder: "URLを入力 https://www ~ ", class: "Form__area"
+      = f.text_field :name, placeholder: "サイト名を入力 例：google", class: "Form__area"
+      = f.text_field :url, placeholder: "URLを入力 例：https://www ~ ", class: "Form__area"
       = f.text_field :comment, placeholder: "コメントを入力してください", class: "Form__area"
     .Form__btn
       = f.submit "追加", class: "Form__btn__area"


### PR DESCRIPTION
# what
ログインしていないユーザーが、別のページを直接リンクで開けないよう制限。
ログインしていない状態で別リンクを開こうとすると、root_path（ホームページ）へ行くように設定。

# Why
ログインしていないユーザーが、勝手に編集や削除ができないようにする為。